### PR TITLE
🧪 [fix(tools): add test coverage for mnemoForget]

### DIFF
--- a/tests/memory.tool.test.ts
+++ b/tests/memory.tool.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MnemoBridge } from '../src/bridge.js'
+import { mnemoForget } from '../src/tools/memory.js'
+
+// Mock MnemoBridge
+vi.mock('../src/bridge.js', () => {
+  return {
+    MnemoBridge: {
+      getInstance: vi.fn()
+    }
+  }
+})
+
+describe('mnemoForget', () => {
+  let mockBridge: any
+  let mockContext: any
+
+  beforeEach(() => {
+    // Reset mocks
+    vi.clearAllMocks()
+
+    // Setup bridge mock
+    mockBridge = {
+      callTool: vi.fn()
+    }
+
+    // Configure getInstance to return our mockBridge
+    ;(MnemoBridge.getInstance as any).mockReturnValue(mockBridge)
+
+    // Setup context mock
+    mockContext = {
+      metadata: vi.fn(),
+      directory: '/test/project'
+    }
+  })
+
+  it('successfully deletes a memory', async () => {
+    const memoryId = 'mem-123'
+
+    // Mock successful response
+    mockBridge.callTool.mockResolvedValue({
+      id: memoryId,
+      status: 'ok'
+    })
+
+    const args = { memory_id: memoryId }
+    const result = await mnemoForget.execute(args, mockContext)
+
+    // Verify context metadata was set
+    expect(mockContext.metadata).toHaveBeenCalledWith({ title: `Deleting memory: ${memoryId}` })
+
+    // Verify bridge call
+    expect(mockBridge.callTool).toHaveBeenCalledWith('memory', {
+      action: 'delete',
+      memory_id: memoryId
+    })
+
+    // Verify success message
+    expect(result).toBe(`Successfully deleted memory ${memoryId}. The fact has been permanently removed.`)
+  })
+
+  it('handles errors during deletion', async () => {
+    const memoryId = 'mem-error'
+    const errorMessage = 'Memory not found'
+
+    // Mock failure response
+    mockBridge.callTool.mockRejectedValue(new Error(errorMessage))
+
+    const args = { memory_id: memoryId }
+    const result = await mnemoForget.execute(args, mockContext)
+
+    // Verify bridge call happened
+    expect(mockBridge.callTool).toHaveBeenCalledWith('memory', {
+      action: 'delete',
+      memory_id: memoryId
+    })
+
+    // Verify error message format
+    expect(result).toBe(`Failed to delete memory: ${errorMessage}`)
+  })
+})


### PR DESCRIPTION
**What:** Add test coverage for `mnemoForget` tool.
**Coverage:** 
- Successful deletion (happy path)
- Error handling (bridge failure)
**Result:** Increased test coverage for `mnemoForget` tool execution logic.

---
*PR created automatically by Jules for task [7665114791170307933](https://jules.google.com/task/7665114791170307933) started by @n24q02m*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for the memory deletion functionality, covering successful deletions and error handling scenarios with mocked dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->