### PR TITLE
refactor: extract getProjectName to src/utils.ts

### DIFF
--- a/src/hooks/auto-capture.ts
+++ b/src/hooks/auto-capture.ts
@@ -11,6 +11,7 @@ import { logger } from '../logger.js'
 
 import type { Event } from '@opencode-ai/sdk'
 import { MnemoBridge } from '../bridge.js'
+import { getProjectName } from '../utils.js'
 
 /** Buffer of user message texts accumulated during the session */
 const sessionBuffer: string[] = []
@@ -38,13 +39,6 @@ function hashContent(content: string): string {
     hash = ((hash << 5) - hash + char) | 0
   }
   return hash.toString(36)
-}
-
-/** Extract project name from directory path */
-function getProjectName(directory: string): string {
-  const cleanDir = directory.replace(/\\/g, '/')
-  const parts = cleanDir.split('/')
-  return parts[parts.length - 1] || 'unknown'
 }
 
 /** Chat message hook: buffer user text parts */

--- a/src/hooks/system-prompt.ts
+++ b/src/hooks/system-prompt.ts
@@ -9,6 +9,7 @@ import { logger } from '../logger.js'
 
 import type { Model } from '@opencode-ai/sdk'
 import { MnemoBridge } from '../bridge.js'
+import { getProjectName } from '../utils.js'
 
 /** Memory item returned from mnemo-mcp search */
 interface MemoryResult {
@@ -31,13 +32,6 @@ const SELF_AWARENESS = `You have persistent memory via the Mnemo system. You can
 - mnemo_remember: Permanently store new facts, rules, preferences
 - mnemo_forget: Delete outdated or incorrect memories
 Proactively search memory when entering a new codebase or when the user asks about past decisions.`
-
-/** Extract project name from directory path */
-function getProjectName(directory: string): string {
-  const cleanDir = directory.replace(/\\/g, '/')
-  const parts = cleanDir.split('/')
-  return parts[parts.length - 1] || 'unknown'
-}
 
 /** Compute injection budget based on model context limit */
 function computeBudget(model: Model): number {

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -9,6 +9,7 @@
 
 import { type ToolDefinition, tool } from '@opencode-ai/plugin/tool'
 import { MnemoBridge } from '../bridge.js'
+import { getProjectName } from '../utils.js'
 
 /** Memory item returned from mnemo-mcp search results */
 interface Memory {
@@ -16,13 +17,6 @@ interface Memory {
   category: string
   content: string
   tags?: string[]
-}
-
-/** Extract project name from directory path */
-function getProjectName(directory: string): string {
-  const cleanDir = directory.replace(/\\/g, '/')
-  const parts = cleanDir.split('/')
-  return parts[parts.length - 1] || 'unknown'
 }
 
 export const mnemoSearch: ToolDefinition = tool({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,6 @@
+/** Extract project name from directory path */
+export function getProjectName(directory: string): string {
+  const cleanDir = directory.replace(/\\/g, '/')
+  const parts = cleanDir.split('/')
+  return parts[parts.length - 1] || 'unknown'
+}


### PR DESCRIPTION
- 🎯 **What:** Extracted `getProjectName` function from `src/tools/memory.ts`, `src/hooks/auto-capture.ts`, and `src/hooks/system-prompt.ts` into a new shared utility file `src/utils.ts`.
- 💡 **Why:** This reduces code duplication and ensures consistent project name extraction logic across the codebase.
- ✅ **Verification:** Created `src/utils.ts` and updated imports in consuming files. Ran `pnpm check` and `pnpm test` to confirm no regressions. All tests passed.
- ✨ **Result:** Improved maintainability by centralizing utility functions.

---
*PR created automatically by Jules for task [52055955017789617](https://jules.google.com/task/52055955017789617) started by @n24q02m*