### PR TITLE
Refactor auto-capture hooks to use factory pattern

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,13 +8,14 @@
 
 import type { Plugin } from '@opencode-ai/plugin'
 import { MnemoBridge } from './bridge.js'
-import { autoCaptureHook, messageHook } from './hooks/auto-capture.js'
+import { createAutoCaptureHooks } from './hooks/auto-capture.js'
 import { compactionHook } from './hooks/compaction.js'
 import { systemPromptHook } from './hooks/system-prompt.js'
 import { mnemoForget, mnemoRemember, mnemoSearch } from './tools/memory.js'
 
 const plugin: Plugin = async (input) => {
   const bridge = MnemoBridge.getInstance()
+  const { messageHook, autoCaptureHook } = createAutoCaptureHooks()
 
   // Start bridge connection in background (non-blocking).
   // If this fails, the circuit breaker in MnemoBridge will prevent repeated


### PR DESCRIPTION
Refactored `src/hooks/auto-capture.ts` to use a factory pattern, encapsulating session state (`sessionBuffer`, `capturedHashes`, `lastCaptureTime`) within the `createAutoCaptureHooks` function. This prevents data leakage and concurrency issues when multiple plugin instances are active. Updated `src/index.ts` to instantiate the hooks correctly and updated `tests/auto-capture.test.ts` to verify the new structure.

- `src/hooks/auto-capture.ts`: Export `createAutoCaptureHooks` factory instead of individual hooks.
- `src/index.ts`: Use `createAutoCaptureHooks` inside `plugin` function.
- `tests/auto-capture.test.ts`: Update tests to use the factory and test isolation.

---
*PR created automatically by Jules for task [18060335850629922226](https://jules.google.com/task/18060335850629922226) started by @n24q02m*