### PR TITLE
🔒 Fix Security Vulnerability: Sensitive Data Leak in Error Logs (Auto-Capture)

### DIFF
--- a/src/hooks/auto-capture.ts
+++ b/src/hooks/auto-capture.ts
@@ -104,6 +104,14 @@ async function processCapture(directory: string) {
 
     logger.info(`[Mnemo] Auto-captured a new rule for ${projectName}`)
   } catch (error) {
-    logger.error(`[Mnemo] Error in auto-capture: ${error}`)
+    let errorMessage: string
+    if (error instanceof Error) {
+      errorMessage = error.message
+    } else if (typeof error === 'object' && error !== null && 'message' in error) {
+      errorMessage = String((error as any).message)
+    } else {
+      errorMessage = String(error)
+    }
+    logger.error(`[Mnemo] Error in auto-capture: ${errorMessage}`)
   }
 }

--- a/tests/security-logging.test.ts
+++ b/tests/security-logging.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Create a mock logger instance to track calls
+const mockLogger = {
+  info: vi.fn(),
+  error: vi.fn()
+}
+
+// Mock the logger module
+vi.mock('../src/logger.js', () => ({
+  logger: mockLogger
+}))
+
+// Dynamic import type
+type AutoCapture = typeof import('../src/hooks/auto-capture.js')
+
+async function freshModule() {
+  vi.resetModules()
+
+  const mockIsAvailable = vi.fn().mockReturnValue(true)
+  const mockCallTool = vi.fn().mockResolvedValue({ status: 'saved' })
+
+  // Mock bridge
+  vi.doMock('../src/bridge.js', () => ({
+    MnemoBridge: {
+      getInstance: () => ({
+        isAvailable: mockIsAvailable,
+        callTool: mockCallTool
+      })
+    }
+  }))
+
+  // Re-mock logger for fresh module context if needed
+  vi.doMock('../src/logger.js', () => ({
+    logger: mockLogger
+  }))
+
+  const mod: AutoCapture = await import('../src/hooks/auto-capture.js')
+  return { mod, mockIsAvailable, mockCallTool }
+}
+
+describe('security reproduction', () => {
+  it('should log error message directly to avoid leaking sensitive data via toString()', async () => {
+    const { mod, mockCallTool } = await freshModule()
+
+    // Create a custom error object that has a safe 'message' but leaks secrets in 'toString()'
+    const sensitiveError = {
+      message: 'Something went wrong (safe)',
+      toString: () => 'Error: Something went wrong with API_KEY=SECRET_12345',
+      stack: 'Error stack...'
+    }
+
+    // Mock the tool call to reject with this sensitive error
+    mockCallTool.mockRejectedValue(sensitiveError)
+
+    // Trigger error path
+    await mod.messageHook(
+      {},
+      {
+        parts: [{ type: 'text', text: 'Always use secure coding practices' }]
+      }
+    )
+
+    await mod.autoCaptureHook({ event: { type: 'session.idle' } as any }, '/home/user/app')
+
+    // Verify logger.error was called
+    expect(mockLogger.error).toHaveBeenCalled()
+    const logMessage = mockLogger.error.mock.calls[0][0]
+
+    // Expect failure initially: current code interpolates `${error}`, which calls toString()
+    // This leaks "API_KEY=SECRET_12345"
+
+    // We want to ensure that the sensitive data is NOT present in the log
+    expect(logMessage).not.toContain('API_KEY=SECRET_12345')
+
+    // And verify that we DO see the safe message
+    expect(logMessage).toContain('Something went wrong (safe)')
+  })
+})


### PR DESCRIPTION
**Issue:**
The `autoCaptureHook` was logging error objects directly using string interpolation (`${error}`), which implicitly calls `toString()`. This could leak sensitive internal state or secrets if the error object's `toString()` method includes them (e.g., custom error objects, API responses).

**Risk:**
Potential exposure of sensitive data (API keys, tokens, user PII) in logs if an error occurs during auto-capture.

**Solution:**
Modified the error handling logic to explicitly extract and log only the `message` property of the error object.
- If `error` is an instance of `Error`, logs `error.message`.
- If `error` is an object with a `message` property (duck typing), logs that message.
- Falls back to `String(error)` only if necessary.

**Verification:**
- Added a new regression test `tests/security-logging.test.ts` that reproduces the vulnerability (by using a custom error with a sensitive `toString()`) and confirms the fix prevents the leak.
- Verified that all existing tests pass (`pnpm test`).
- Verified code formatting and linting (`pnpm check`).

---
*PR created automatically by Jules for task [13562518587222667134](https://jules.google.com/task/13562518587222667134) started by @n24q02m*