### PR TITLE
fix(hooks): limit session buffer size to prevent memory growth

### DIFF
--- a/src/hooks/auto-capture.ts
+++ b/src/hooks/auto-capture.ts
@@ -27,6 +27,9 @@ const IDLE_THRESHOLD = 60_000
 /** Maximum content length to store per auto-capture */
 const MAX_CAPTURE_LENGTH = 500
 
+/** Maximum number of messages to keep in session buffer */
+const MAX_SESSION_BUFFER_SIZE = 100
+
 /** Regex to detect constraint-like user statements */
 const CONSTRAINT_REGEX = /\b(always|never|must|prefer|don't|do not|should not|make sure|ensure|require)\b/i
 
@@ -56,6 +59,9 @@ export const messageHook = async (_input: unknown, output: { parts: { type: stri
     .trim()
 
   if (userText) {
+    if (sessionBuffer.length >= MAX_SESSION_BUFFER_SIZE) {
+      sessionBuffer.shift()
+    }
     sessionBuffer.push(userText)
   }
 }

--- a/tests/auto-capture.test.ts
+++ b/tests/auto-capture.test.ts
@@ -249,5 +249,29 @@ describe('auto-capture', () => {
         expect(mockCallTool).toHaveBeenCalled()
       }
     })
+
+    it('enforces maximum buffer size', async () => {
+      const { mod, mockCallTool } = await freshModule()
+
+      // Push 101 messages
+      for (let i = 0; i < 101; i++) {
+        await mod.messageHook(
+          {},
+          {
+            parts: [{ type: 'text', text: `Always message ${i}` }]
+          }
+        )
+      }
+
+      await mod.autoCaptureHook({ event: { type: 'session.idle' } as any }, '/home/user/app')
+
+      const callArgs = mockCallTool.mock.calls[0][1]
+
+      // Should NOT contain "Always message 0" (shifted out)
+      expect(callArgs.content).not.toContain('Always message 0')
+
+      // Should contain "Always message 1" (new head)
+      expect(callArgs.content).toContain('Always message 1')
+    })
   })
 })


### PR DESCRIPTION
- Fixed a potential unbounded memory growth vulnerability in `src/hooks/auto-capture.ts`.
- The `sessionBuffer` array could grow indefinitely if a session had many messages without triggering an idle capture.
- Introduced `MAX_SESSION_BUFFER_SIZE` (100) to limit the buffer size.
- Implemented a circular buffer strategy: when the buffer is full, the oldest message is removed.
- Added a regression test in `tests/auto-capture.test.ts` to verify the buffer limit is enforced.

---
*PR created automatically by Jules for task [5578943040892367046](https://jules.google.com/task/5578943040892367046) started by @n24q02m*