### PR TITLE
🔒 Fix unpinned external tool version in bridge.ts

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -122,7 +122,7 @@ export class MnemoBridge {
     // Windows execution automatically, so we just use 'uvx' (not 'uvx.cmd')
     this.transport = new StdioClientTransport({
       command: 'uvx',
-      args: ['mnemo-mcp'],
+      args: ['mnemo-mcp@1.2.0'],
       stderr: 'ignore', // Prevent stderr backpressure and log noise
       env: { ...process.env, LOG_LEVEL: 'WARNING' }
     })

--- a/tests/bridge.unit.test.ts
+++ b/tests/bridge.unit.test.ts
@@ -22,6 +22,8 @@ vi.mock('@modelcontextprotocol/sdk/types.js', () => ({
   CallToolResultSchema: {}
 }))
 
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { MnemoBridge } from '../src/bridge.js'
 
 /**
@@ -115,6 +117,29 @@ describe('MnemoBridge', () => {
   })
 
   describe('connect', () => {
+    it('initializes StdioClientTransport with pinned mnemo-mcp version', async () => {
+      const bridge = MnemoBridge.getInstance()
+
+      const mockClientInstance = {
+        connect: vi.fn().mockResolvedValue(undefined),
+        listTools: vi.fn().mockResolvedValue({ tools: [] })
+      }
+
+      // biome-ignore lint/complexity/useArrowFunction: Vitest mock constructor requires function expression
+      vi.mocked(Client).mockImplementation(function () {
+        return mockClientInstance
+      } as any)
+
+      await bridge.connect()
+
+      expect(StdioClientTransport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: 'uvx',
+          args: ['mnemo-mcp@1.2.0']
+        })
+      )
+    })
+
     it('connects and caches available tools', async () => {
       const bridge = MnemoBridge.getInstance()
       setupBridgeWithMockConnect(bridge)


### PR DESCRIPTION
This PR addresses a security vulnerability where the `mnemo-mcp` tool was executed without a pinned version.

Changes:
- Modified `src/bridge.ts` to pin `mnemo-mcp` to version `1.2.0` when using `uvx`.
- Added a unit test in `tests/bridge.unit.test.ts` to verify that `StdioClientTransport` is initialized with the correct pinned version.

This prevents potential supply chain attacks where a malicious update to the latest version of `mnemo-mcp` could be automatically executed.

---
*PR created automatically by Jules for task [793591705727181940](https://jules.google.com/task/793591705727181940) started by @n24q02m*