### PR TITLE
🔒 Fix unsafe environment variable propagation in bridge

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -12,6 +12,7 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { getSafeEnv } from './env.js'
 
 /** Result content item from MCP tool call */
 interface ContentItem {
@@ -124,7 +125,7 @@ export class MnemoBridge {
       command: 'uvx',
       args: ['mnemo-mcp'],
       stderr: 'ignore', // Prevent stderr backpressure and log noise
-      env: { ...process.env, LOG_LEVEL: 'WARNING' }
+      env: getSafeEnv(process.env)
     })
 
     this.client = new Client(

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,63 @@
+/**
+ * Filter environment variables to prevent accidental secret leakage.
+ * Only allows standard system variables, specific application prefixes,
+ * and explicitly required variables.
+ */
+export function getSafeEnv(processEnv: Record<string, string | undefined>): Record<string, string> {
+  const safeEnv: Record<string, string> = {}
+
+  // 1. Explicitly allow-list standard variables
+  const ALLOW_LIST = [
+    // System paths
+    'PATH',
+    'Path', // Windows often uses mixed case
+    'HOME',
+    'USERPROFILE', // Windows
+    'APPDATA', // Windows
+    'LOCALAPPDATA', // Windows
+    'TEMP',
+    'TMP',
+    'SYSTEMROOT', // Windows
+    'SystemRoot', // Windows
+    'DB_PATH', // Used in tests
+
+    // Proxy configuration (often critical for corporate networks)
+    'HTTP_PROXY',
+    'HTTPS_PROXY',
+    'NO_PROXY',
+    'ALL_PROXY',
+    'http_proxy',
+    'https_proxy',
+    'no_proxy',
+    'all_proxy',
+
+    // Terminal settings (sometimes needed for tools)
+    'TERM',
+    'COLORTERM'
+  ]
+
+  // 2. Allow-list by prefix
+  const ALLOW_PREFIXES = ['UV_', 'MNEMO_', 'PYTHON', 'XDG_']
+
+  for (const key of Object.keys(processEnv)) {
+    const value = processEnv[key]
+    if (value === undefined) continue
+
+    if (ALLOW_LIST.includes(key)) {
+      safeEnv[key] = value
+      continue
+    }
+
+    for (const prefix of ALLOW_PREFIXES) {
+      if (key.startsWith(prefix)) {
+        safeEnv[key] = value
+        break
+      }
+    }
+  }
+
+  // 3. Force LOG_LEVEL to WARNING
+  safeEnv.LOG_LEVEL = 'WARNING'
+
+  return safeEnv
+}

--- a/tests/bridge-env.test.ts
+++ b/tests/bridge-env.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { getSafeEnv } from '../src/env.js'
+
+describe('getSafeEnv', () => {
+  it('should filter out sensitive variables', () => {
+    const mockEnv = {
+      PATH: '/usr/bin',
+      HOME: '/home/user',
+      SECRET_KEY: 'super-secret',
+      OPENAI_API_KEY: 'sk-12345',
+      DB_PATH: '/tmp/test.db',
+      MNEMO_CONFIG: 'some-config',
+      UV_CACHE_DIR: '/cache',
+      PYTHONPATH: '/lib/python',
+      XDG_CONFIG_HOME: '/config',
+      OTHER_VAR: 'should-be-gone'
+    }
+
+    const safeEnv = getSafeEnv(mockEnv)
+
+    expect(safeEnv.PATH).toBe('/usr/bin')
+    expect(safeEnv.HOME).toBe('/home/user')
+    expect(safeEnv.DB_PATH).toBe('/tmp/test.db')
+    expect(safeEnv.MNEMO_CONFIG).toBe('some-config')
+    expect(safeEnv.UV_CACHE_DIR).toBe('/cache')
+    expect(safeEnv.PYTHONPATH).toBe('/lib/python')
+    expect(safeEnv.XDG_CONFIG_HOME).toBe('/config')
+
+    expect(safeEnv.SECRET_KEY).toBeUndefined()
+    expect(safeEnv.OPENAI_API_KEY).toBeUndefined()
+    expect(safeEnv.OTHER_VAR).toBeUndefined()
+
+    // Verify LOG_LEVEL override/default
+    expect(safeEnv.LOG_LEVEL).toBe('WARNING')
+  })
+
+  it('should handle undefined values gracefully', () => {
+    const mockEnv = {
+      PATH: '/usr/bin',
+      UNDEFINED_VAR: undefined
+    }
+    const safeEnv = getSafeEnv(mockEnv)
+    expect(safeEnv.PATH).toBe('/usr/bin')
+    expect(safeEnv.UNDEFINED_VAR).toBeUndefined()
+  })
+
+  it('should include Windows Path', () => {
+    const mockEnv = {
+      Path: 'C:\\Windows'
+    }
+    const safeEnv = getSafeEnv(mockEnv)
+    expect(safeEnv.Path).toBe('C:\\Windows')
+  })
+
+  it('should include proxy variables', () => {
+    const mockEnv = {
+      HTTP_PROXY: 'http://proxy.com',
+      https_proxy: 'http://proxy.com',
+      NO_PROXY: 'localhost'
+    }
+    const safeEnv = getSafeEnv(mockEnv)
+    expect(safeEnv.HTTP_PROXY).toBe('http://proxy.com')
+    expect(safeEnv.https_proxy).toBe('http://proxy.com')
+    expect(safeEnv.NO_PROXY).toBe('localhost')
+  })
+})


### PR DESCRIPTION
🎯 **What:**
Fixed a security vulnerability where sensitive environment variables were being passed to the child process (`uvx mnemo-mcp`) in `src/bridge.ts`.

⚠️ **Risk:**
Passing `process.env` directly could leak secrets (e.g., API keys, tokens) to the child process or its dependencies if they log the environment or are compromised.

🛡️ **Solution:**
Implemented an allow-list approach in `src/env.ts` (`getSafeEnv`) to filter environment variables before passing them to the child process. The allow-list includes:
- Standard system variables (PATH, HOME, etc.) with Windows support (Path, SystemRoot).
- Proxy variables (HTTP_PROXY, NO_PROXY, etc.).
- Application-specific prefixes (UV_, MNEMO_, PYTHON, XDG_).
- Explicitly sets `LOG_LEVEL=WARNING`.

Verified with a new test suite `tests/bridge-env.test.ts`.

---
*PR created automatically by Jules for task [5872434374002210668](https://jules.google.com/task/5872434374002210668) started by @n24q02m*